### PR TITLE
socraticbot.framer.ai -> socratic.bot

### DIFF
--- a/assets/javascripts/discourse/initializers/custom-modal-button.js
+++ b/assets/javascripts/discourse/initializers/custom-modal-button.js
@@ -22,7 +22,7 @@ function initializeWithApi(api) {
         const textValue = editor.getText();
         const test = encodeURIComponent(textValue);
         //Replace with actual URL
-        const encodedTextValue = `https://socraticbot.framer.ai/agora?q=${test}`;
+        const encodedTextValue = `https://socratic.bot/agora?q=${test}`;
         toolbar.context.send("openSocraticModal", textValue, encodedTextValue);
       },
     });
@@ -52,7 +52,7 @@ function getTextAreaValue(api) {
     const test = encodeURIComponent(textValue);
     //Replace with actual URL
     //TO DO: Considerar pass the base URL as param or with .env, could be fun !
-    const encodedTextValue = `https://socraticbot.framer.ai/agora?q=${test}`;
+    const encodedTextValue = `https://socratic.bot/agora?q=${test}`;
 
     // Open the modal
     const context = api.container.lookup("component:d-editor");


### PR DESCRIPTION
We're going to be moving Socratic Bot over to the `socratic.bot` domain, and in order to do so we need to delete `socraticbot.framer.ai` as Framer only supports a single custom domain :/

We need to try and coordinate this change landing in Agora + the domain name change, because atm sending people to `https://socratic.bot/agora?q=Foo` will redirect them to just `https://socratic.bot`